### PR TITLE
FIX for var keyword

### DIFF
--- a/src/jquerytojs.php
+++ b/src/jquerytojs.php
@@ -203,7 +203,7 @@ trait DOM
 	 */
 	public static function varToLet()
 	{
-		self::$js = preg_replace('@var\s+([0-9a-zA-Z-_]?)@', 'let $1', self::$js);
+		self::$js = preg_replace('@\bvar\s+([0-9a-zA-Z-_]?)@', 'let $1', self::$js);
 	}
 
 	/**


### PR DESCRIPTION
Fixed for `var currency = "bolivar venezuela";` => `let currency = "bolilet venezuela";` 👍 

Still has bug for `var currency = "bolivar var venezuela";` => `let currency = "bolivar let venezuela";` 👎 